### PR TITLE
Formatting and removed string allocation.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,23 +3,29 @@ use std::io::Write;
 use std::net::TcpListener;
 
 const DEFAULT_PORT: u16 = 3000;
-const DEFAULT_REDIRECT: &str = "https://hack.gt";
-const LISTENING_ADDRESS: &str = "0.0.0.0";
+const DEFAULT_REDIRECT: &'static str = "https://hack.gt";
+const LISTENING_ADDRESS: &'static str = "0.0.0.0";
 
 fn main() {
-    let port = match env::var("PORT") {
-        Ok(p) => p.parse().unwrap_or(DEFAULT_PORT),
-        Err(_) => DEFAULT_PORT,
-    };
+    let port = env::var("PORT")
+        .map(|p| p.parse().unwrap_or(DEFAULT_PORT))
+        .unwrap_or(DEFAULT_PORT);
 
-    let redirect = env::var("REDIRECT_URL").unwrap_or_else(|_| DEFAULT_REDIRECT.to_string());
+    let redirect = env::var("REDIRECT_URL");
+    let redirect = redirect
+        .as_ref().map(|s| &**s)
+        .unwrap_or(DEFAULT_REDIRECT);
 
-    let header = format!("HTTP/1.1 307 Temporary Redirect\r\nLocation: {}\r\n\r\n", redirect);
+    let header = format!(
+        "HTTP/1.1 307 Temporary Redirect\r\n\
+         Location: {}\r\n\
+         \r\n", redirect);
     let header = header.as_bytes();
 
-    let listener = TcpListener::bind((LISTENING_ADDRESS, port)).expect("Failed to bind to address! Are you trying to listen to ports <= 1024 without root access?");
+    let listener = TcpListener::bind((LISTENING_ADDRESS, port))
+        .expect("Failed to bind to address! Are you trying to listen to ports <= 1024 without root access? Or is a process already using that port?");
 
-    println!("Redirector redirecting to {} listening on {}:{}", redirect, LISTENING_ADDRESS, port);
+    println!("Redirecting to {} listening on {}:{}", redirect, LISTENING_ADDRESS, port);
 
     for mut stream in listener.incoming().filter_map(Result::ok) {
         stream.write(header).ok();


### PR DESCRIPTION
Calling `.to_string()` allocates a new string on the heap, avoiding this saves on memory and processing power.